### PR TITLE
Add support to STDIN & STDERR of wrapped command

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ characters. The output is going to be written to `stdout` accordingly. This
 lets you use `black` in `vim` as if it was a regular filter command, which
 makes life much easier for a regular Python dev.
 
+In case the wrapped command writes the formatted code output to `stdout` or
+`stderr`, `duct` has two flags `-stdout` and `-stderr` that attach them to the
+wrapped command instead of redirecting the whole R/W flow through a temporary
+file.
+
 
 ## Development
 

--- a/cmd/duct/doc.go
+++ b/cmd/duct/doc.go
@@ -5,11 +5,13 @@ Duct wraps a code formatter inside of a stdin to stdout filter-like data flow.
 
 Usage:
 
-	duct [args...]
+	duct [OPTIONS] [args...]
 
 Options:
 
-	-h, --help  show this help message and exit
+	-h, -help, --help  show this help message and exit
+	-stdout, --stdout  attach stdout of the wrapped command
+	-stderr, --stderr  attach stderr of the wrapped command
 
 Example:
 
@@ -47,8 +49,11 @@ Output:
 	q = Queue()
 	print_size(q)
 
-The program wraps a code formatter, which accepts file names as commands
+The program wraps a code formatter, which accepts file names as command
 arguments instead of reading from standard input data stream, inside of a
-standard Unix stdin to stdout filter-like data flow.
+standard Unix stdin to stdout filter-like data flow. The -stdout and -stderr
+flags replace stdout and stderr of duct with stdout and stderr of the wrapped
+command. It proves useful when the wrapped command reads code from files but
+writes its output to stdout and/or stderr and not directly to provided files.
 */
 package main

--- a/cmd/duct/doc.go
+++ b/cmd/duct/doc.go
@@ -53,7 +53,7 @@ The program wraps a code formatter, which accepts file names as command
 arguments instead of reading from standard input data stream, inside of a
 standard Unix stdin to stdout filter-like data flow. The -stdout and -stderr
 flags replace stdout and stderr of duct with stdout and stderr of the wrapped
-command. It proves useful when the wrapped command reads code from files but
-writes its output to stdout and/or stderr and not directly to provided files.
+command. It's useful when the wrapped command reads code from files but writes
+its output to stdout and/or stderr instead of writing directly to files.
 */
 package main

--- a/doc.go
+++ b/doc.go
@@ -10,5 +10,10 @@ intermediate temporary file. The name of the file gets passed to as one of the
 positional arguments of the named program to be executed. The modified contents
 of the file are then re-read and written out the standard output. This way the
 wrapped program can be used as a regular Unix filter.
+
+Some code formatters take file names but do not modify files directly. Instead
+they write the formatted code to stdout or stderr. This scenario is supported
+by a the WrapWrite function that writes code from stdin to the temporary file
+but relies on the command's own stdout and/or stderr to write out the output.
 */
 package duct

--- a/duct.go
+++ b/duct.go
@@ -107,15 +107,16 @@ func Wrap(cmd Runner, fds *FDs) error {
 	return nil
 }
 
-// WrapXXX ...
-func WrapXXX(cmd Runner, fds *FDs) error {
+// WrapWrite executes the provided named formatter program wrapping the
+// temporary file write operation.
+//
+// Code to be formatted is read from the fds.Stdin and written to fds.TempFile
+// to allow the wrapped command to read code from the temporary file and handle
+// its output using the command's own stdout and/or stderr.
+func WrapWrite(cmd Runner, fds *FDs) error {
 	in := bufio.NewReader(fds.Stdin)
 	_, err := in.WriteTo(fds.TempFile)
 	if err != nil && !errors.Is(err, io.EOF) {
-		return err
-	}
-	_, err = fds.TempFile.Seek(0, 0)
-	if err != nil {
 		return err
 	}
 	err = cmd.Run()

--- a/duct.go
+++ b/duct.go
@@ -12,7 +12,7 @@ const Pattern = `duct-*`
 
 // Discard is a WriteCloser that does nothing when either Write or Close
 // methods are invoked. Ever call succeeds.
-var Discard io.WriteCloser = discard{}
+var Discard discard
 
 // NilFDError indicates that a file descriptor for read/write operation is nil.
 var NilFDError error = errors.New("nil file descriptor")
@@ -102,6 +102,24 @@ func Wrap(cmd Runner, fds *FDs) error {
 	out := bufio.NewWriter(fds.Stdout)
 	_, err = out.ReadFrom(fds.TempFile)
 	if err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	return nil
+}
+
+// WrapXXX ...
+func WrapXXX(cmd Runner, fds *FDs) error {
+	in := bufio.NewReader(fds.Stdin)
+	_, err := in.WriteTo(fds.TempFile)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	_, err = fds.TempFile.Seek(0, 0)
+	if err != nil {
+		return err
+	}
+	err = cmd.Run()
+	if err != nil {
 		return err
 	}
 	return nil

--- a/duct.go
+++ b/duct.go
@@ -107,13 +107,13 @@ func Wrap(cmd Runner, fds *FDs) error {
 	return nil
 }
 
-// WrapWrite executes the provided named formatter program wrapping the
+// WrapWriteOnly executes the provided named formatter program wrapping the
 // temporary file write operation.
 //
 // Code to be formatted is read from the fds.Stdin and written to fds.TempFile
 // to allow the wrapped command to read code from the temporary file and handle
 // its output using the command's own stdout and/or stderr.
-func WrapWrite(cmd Runner, fds *FDs) error {
+func WrapWriteOnly(cmd Runner, fds *FDs) error {
 	in := bufio.NewReader(fds.Stdin)
 	_, err := in.WriteTo(fds.TempFile)
 	if err != nil && !errors.Is(err, io.EOF) {


### PR DESCRIPTION
- Added wrap with FD0 and/or FD1 to wrapped cmd
- Added FD0 and/or FD1 to CLI command
- Modified package documentation on WrapWrite func
- Implemented WrapWrite command using cmd's FD1/2
- Added FD1/2 of wrapped command to duct CLI
- Completed duct cmd implementation
- Added unit tests for WrapWriteOnly wrapper func
- Modified the README file to mention FD0 & FD1
