### PR TITLE
Fix CI file for repository

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [ '1.19', '1.21' ]
+        go-version: [ '1.21' ]
         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -38,8 +38,11 @@ jobs:
     - name: Test
       run: go test -v -coverprofile coverage.txt -covermode atomic ./...
 
-    - name: Coverage
+    - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true
 
     - name: Test formatter
       run: go build -o duct cmd/duct/main.go && echo -n class A':' pass | ./duct black -l 79


### PR DESCRIPTION
- Remove Go version 1.21 from the github CI file
- Fix codecov update action in github CI
- Do not trigger CI on develop branch
